### PR TITLE
docs: add meshery-extensions link to help wanted section (fixes #65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Our projects are community-built and welcome collaboration. 👍 Be sure to see 
 ✔️ <em>Fill-in</em> a <a href="https://layer5.io/newcomers">community member form</a> to gain access to community resources.<br />
 ✔️ <em><strong>Discuss</strong></em> in the <a href="https://discuss.meshery.io">Community Forum</a>.<br />
 </p>
-<p align="center">
-<i>Not sure where to start?</i> Grab an open issue with the <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Alayer5io+org%3Ameshery+org%3Aservice-mesh-performance+org%3Aservice-mesh-patterns+org%3Ameshery-extensions+label%3A%22help+wanted%22+">help-wanted label</a>.
-</p>
+
+<i>Not sure where to start?</i> Check out open issues across the Meshery ecosystem:
+
+- [Meshery](https://github.com/layer5io/meshery/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- [Meshery Extensions](https://github.com/meshery-extensions/meshery-adapter-template/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+
+
 
 <br />
 <br />


### PR DESCRIPTION
Updated the README to include a link for 'help wanted' issues in the meshery-extensions organization